### PR TITLE
Added support for KAT - Advanced Medical

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ By default fatigue can add up to a whole second per tick. This value is also aff
 
 Also added was the ability to designate items as geiger counters. By default this behavior is added to the Micro DAGR. These play their sounds in 3D space.
 
+### Compatible with KAT Medical
+
+The script will use some of the chemical warfare function from V2.13.0. This includes, intoxication and gas mask filter. 
+
 ## Requirements
 
 CBA_A3 and ACE3
@@ -187,6 +191,12 @@ Float, value that modifies how much fatigue will cause the mask to fog up more.\
 Fatigue is returned in the range of 0 - 1; therefore a fatigue value of 1 and coefficient of 1 can add up to another second of uptime per second.\
 Higher makes fatigue build up far more fog, lower makes fatigue matter less in terms of fogging.\
 default: 1
+
+### cbrn_kat_enabled
+
+Boolean, the config will detect wheather KAT - Advanced Medical is installed or not.
+True will cause the script to read and use KAT chemical warfare data and injuries when neccessary.
+default: auto
 
 # Contributors
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ default: auto
 
 diwako - Main dev  
 Celene - Mask fogging, geiger type
+Alan245 - KAT Compatibility
 
 # Links
 BI Thread: https://forums.bohemia.net/forums/topic/225668-cbrn-script/

--- a/diwako_cbrn.vr/scripts/cbrn/config.sqf
+++ b/diwako_cbrn.vr/scripts/cbrn/config.sqf
@@ -75,3 +75,6 @@ cbrn_vehicles = [
     ["vroomvroom", 5],
     ["B_Quadbike_01_F", 1]
 ];
+
+// Configuration for KAT - Advanced Medical
+cbrn_kat_enabled = isClass(configfile >> "CfgPatches" >> "kat_main");

--- a/diwako_cbrn.vr/scripts/cbrn/functions/fn_handleDamage.sqf
+++ b/diwako_cbrn.vr/scripts/cbrn/functions/fn_handleDamage.sqf
@@ -62,6 +62,7 @@ if (_threadLevel >= 3) then {
 _actualThreat = _actualThreat max 0;
 
 systemChat format ["Actual Threat: %1 | Mitigated Threat: %2", _threadLevel, _actualThreat];
+// systemChat format ["Actual Threat: %1 | Mitigated Threat: %2", _threadLevel, _actualThreat];
 
 if (_actualThreat < 1) exitWith {
     cbrn_mask_damage ppEffectAdjust [0, 0, true];

--- a/diwako_cbrn.vr/scripts/cbrn/functions/fn_handleDamage.sqf
+++ b/diwako_cbrn.vr/scripts/cbrn/functions/fn_handleDamage.sqf
@@ -31,7 +31,8 @@ if (_vehicle isNotEqualTo _unit) then {
     _actualThreat = _actualThreat - (_vehicle getVariable ["cbrn_proofing", 0]);
 };
 
-if (_threadLevel > 0 && cbrn_kat_enabled) then {
+// when the contamination require gasmask only, consume filter in KAT
+if (_threadLevel > 0 && _threadLevel < 2 && cbrn_kat_enabled) then {
     _unit setVariable ["kat_chemical_enteredPoison", true];
 } else {
     _unit setVariable ["kat_chemical_enteredPoison", false];

--- a/diwako_cbrn.vr/scripts/cbrn/functions/fn_handleDamage.sqf
+++ b/diwako_cbrn.vr/scripts/cbrn/functions/fn_handleDamage.sqf
@@ -31,10 +31,21 @@ if (_vehicle isNotEqualTo _unit) then {
     _actualThreat = _actualThreat - (_vehicle getVariable ["cbrn_proofing", 0]);
 };
 
+if (_threadLevel > 0 && cbrn_kat_enabled) then {
+    _unit setVariable ["kat_chemical_enteredPoison", true];
+} else {
+    _unit setVariable ["kat_chemical_enteredPoison", false];
+};
+
 if (_threadLevel >= 1) then {
     // level 2 threat
     // requires mask
-    _actualThreat = _actualThreat - ([0,1] select (_unit getVariable ["cbrn_mask_on", false]));
+    if (cbrn_kat_enabled) then {
+        private _gasMaskDur = _unit getVariable ["kat_chemical_gasmask_durability", 0] > 0;
+        _actualThreat = _actualThreat - ([0,1] select (_gasMaskDur && _unit getVariable ["cbrn_mask_on", false]));
+    } else {
+        _actualThreat = _actualThreat - ([0,1] select (_unit getVariable ["cbrn_mask_on", false]));
+    };
 };
 if (_threadLevel >= 2) then {
     // level 3 threat
@@ -49,13 +60,17 @@ if (_threadLevel >= 3) then {
 
 _actualThreat = _actualThreat max 0;
 
-// systemChat format ["Actual Threat: %1 | Mitigated Threat: %2", _threadLevel, _actualThreat];
+systemChat format ["Actual Threat: %1 | Mitigated Threat: %2", _threadLevel, _actualThreat];
 
 if (_actualThreat < 1) exitWith {
     cbrn_mask_damage ppEffectAdjust [0, 0, true];
     cbrn_mask_damage ppEffectCommit 5;
 };
 
+// Cause the unit to have intoxication in KAT
+if (cbrn_kat_enabled) then {
+    _unit setVariable ["kat_chemical_airPoisoning", true];
+};
 
 private _effectStrength = _actualThreat / 5;
 

--- a/diwako_cbrn.vr/scripts/cbrn/functions/fn_handleDamage.sqf
+++ b/diwako_cbrn.vr/scripts/cbrn/functions/fn_handleDamage.sqf
@@ -32,10 +32,12 @@ if (_vehicle isNotEqualTo _unit) then {
 };
 
 // when the contamination require gasmask only, consume filter in KAT
-if (_threadLevel > 0 && _threadLevel < 2 && cbrn_kat_enabled) then {
-    _unit setVariable ["kat_chemical_enteredPoison", true];
-} else {
-    _unit setVariable ["kat_chemical_enteredPoison", false];
+if (cbrn_kat_enabled) then {
+    if (_threadLevel > 0 && {_threadLevel < 2}) then {
+        _unit setVariable ["kat_chemical_enteredPoison", true];
+    } else {
+        _unit setVariable ["kat_chemical_enteredPoison", false];
+    };
 };
 
 if (_threadLevel >= 1) then {

--- a/diwako_cbrn.vr/scripts/cbrn/functions/fn_handleDamage.sqf
+++ b/diwako_cbrn.vr/scripts/cbrn/functions/fn_handleDamage.sqf
@@ -61,7 +61,6 @@ if (_threadLevel >= 3) then {
 
 _actualThreat = _actualThreat max 0;
 
-systemChat format ["Actual Threat: %1 | Mitigated Threat: %2", _threadLevel, _actualThreat];
 // systemChat format ["Actual Threat: %1 | Mitigated Threat: %2", _threadLevel, _actualThreat];
 
 if (_actualThreat < 1) exitWith {

--- a/diwako_cbrn.vr/scripts/cbrn/functions/fn_loadoutEH.sqf
+++ b/diwako_cbrn.vr/scripts/cbrn/functions/fn_loadoutEH.sqf
@@ -5,6 +5,10 @@ private _backpack = backpack _unit;
 private _uniform = uniform _unit;
 
 private _hasMask = (cbrn_masks findIf {_x isEqualTo _goggles}) > -1;
+if !(_hasMask && cbrn_kat_enabled) then {
+    _hasMask = (missionNamespace getVariable ["kat_chemical_availGasmaskList",[]] findIf {_x isEqualTo _goggles}) > -1;
+};
+
 if (!(_unit getVariable ["cbrn_mask_on", false]) && {_hasMask}) then {
     // guy JUST put that mask on
     _unit setVariable ["cbrn_mask_on", true, true];

--- a/diwako_cbrn.vr/scripts/cbrn/functions/fn_loadoutEH.sqf
+++ b/diwako_cbrn.vr/scripts/cbrn/functions/fn_loadoutEH.sqf
@@ -5,7 +5,7 @@ private _backpack = backpack _unit;
 private _uniform = uniform _unit;
 
 private _hasMask = (cbrn_masks findIf {_x isEqualTo _goggles}) > -1;
-if !(_hasMask && cbrn_kat_enabled) then {
+if !(_hasMask && {cbrn_kat_enabled}) then {
     _hasMask = (missionNamespace getVariable ["kat_chemical_availGasmaskList",[]] findIf {_x isEqualTo _goggles}) > -1;
 };
 


### PR DESCRIPTION
The pull request will be able to utilize the following feature in KAT - Advanced Medical
- When in a gas mask-only zone (threat level above 0 and below 2), the filter durability in KAT will be consumed.
- When the handleDamage.sqf considers the unit is not protected enough and received cbrn_damage, it will give the unit an "intoxication" condition in KAT as well.
- In the file fn_loadoutEH.sqf, the script will also check for the gas mask registered in the KAT parameter.

All features should not introduce dependencies for KAT medical as features only run if the mod is detected in the missionNamespace and tested in SP only.